### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 - 新規の設置には [yubinbango](https://github.com/yubinbango/yubinbango)ライブラリの使用をオススメしています。
 
-#ajaxzip3
+# ajaxzip3
 世界一、簡単に設置できる郵便番号検索を目指して！
 
 ▶[ajaxzip3設置サンプルページ](https://ajaxzip3.github.io/sample-page/)◀
 
-###最新のお知らせ
+### 最新のお知らせ
 
 - 新規の設置には [yubinbango](https://github.com/yubinbango/yubinbango)ライブラリの使用をオススメしています。
 - Google Codeのサービス廃止によりGithubに移行いたしました。
 - Github移行を機にこれまでhttp、httpsで分かれていたURLを一本化いたしました。  
 今後は、https://ajaxzip3.github.io/ajaxzip3.js をご利用ください。
 
-###Google Code版からGithub版への移行ガイド
+### Google Code版からGithub版への移行ガイド
 HTML中の
 
     <script src="http://ajaxzip3.googlecode.com/svn/trunk/ajaxzip3/ajaxzip3.js" charset="UTF-8"></script>
@@ -24,7 +24,7 @@ HTML中の
 に変更する。  
 以上。
 
-##ajaxzip3とは
+## ajaxzip3とは
 もう郵便番号データをサーバにインストールする必要はありません。
 
 [株式会社人気組](https://ninkigumi.com)（本社：東京都千代田区、代表取締役：[小林照幸](https://plus.google.com/+小林照幸)）が中心となって [ajaxzip2](http://www.kawa.net/works/ajax/ajaxzip2/ajaxzip2.html) を JSONP に対応させ、ajaxzip3 として新たに公開いたしました。
@@ -35,7 +35,7 @@ HTML中の
 
 ＃郵便番号データのソースは[郵便事業株式会社（旧郵政省）提供のデータ](http://www.post.japanpost.jp/zipcode/download.html)を使用しています。なお、郵便番号データの更新作業自体は1コマンドで完了しますが、エラー発生を考慮し（過去には実際に郵便事業株式会社側でのデータ化ミス等の事例もあります）敢えてcronでの完全自動化は行わず最後のひと手間については手作業にて行っております。
 
-###オリジナルからの変更点
+### オリジナルからの変更点
 
 - Javascriptライブラリのprototype.jsやJQueryが不要になりました。
 - メンテナンス不要で常に最新版の郵便番号データを利用できるようになりました。（JSONPに対応）
@@ -43,7 +43,7 @@ HTML中の
 - 読み込み時間の短縮。[YUI Compressor](http://yui.github.io/yuicompressor/)を使用してJavascriptコードを圧縮しました。 12KB→5KB （[参考記事](http://www.julienlecomte.net/blog/2007/08/11/)）
 - 引数の順序を変更しました。（詳しくは下記を参照してください）
 
-###利用方法（設定例）
+### 利用方法（設定例）
 ▶[ajaxzip3設置サンプルページ](https://ajaxzip3.github.io/sample-page/)◀
 
 HTMLヘッダ設定例（設置するHTMLのcharsetがUTF-8の場合）
@@ -80,7 +80,7 @@ HTMLヘッダ設定例（設置するHTMLのcharsetがShift_JISの場合）
     <input type="text" name="addr21" size="40">
     <input type="text" name="strt21" size="40">
 
-###注）ajaxzip2を利用していた方へ
+### 注）ajaxzip2を利用していた方へ
 
 オリジナルから引数の順序を変更しました。
 
@@ -92,7 +92,7 @@ HTMLヘッダ設定例（設置するHTMLのcharsetがShift_JISの場合）
     AjaxZip3.zip2addr( '〒上3桁', '〒下4桁', '都道府県', '市区町村', '町域大字', '丁目番地' );
 としました。
 
-###メディア掲載
+### メディア掲載
 
 ・[MOONGIFTさんでご紹介いただきました(2009.3.27)](http://www.moongift.jp/2009/03/ajaxzip3/)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
